### PR TITLE
Fix NPE in JSONDump

### DIFF
--- a/src/main/java/org/yinwang/rubysonar/JSONDump.java
+++ b/src/main/java/org/yinwang/rubysonar/JSONDump.java
@@ -104,12 +104,14 @@ public class JSONDump {
                         args.append("(");
                         boolean first = true;
 
-                        for (Node n : func.args) {
-                            if (!first) {
-                                args.append(", ");
+                        if (func.args != null ) {
+                            for (Node n : func.args) {
+                                if (!first) {
+                                    args.append(", ");
+                                }
+                                first = false;
+                                args.append(n.toDisplay());
                             }
-                            first = false;
-                            args.append(n.toDisplay());
                         }
 
                         if (func.vararg != null) {


### PR DESCRIPTION
The following command yields an NPE:

```
$ java -cp target/rubysonar-0.1-SNAPSHOT.jar org.yinwang.rubysonar.JSONDump tests/include.test/include.rb '' foo
copied models to: /tmp/pysonar2/models.f4a382bb-d4d8-4fdc-b00b-ea52ce1eb932
AST cache is at: /tmp/rubysonar/ast_cache
started: irb
100% (1 of 1)   SPEED:     0/s   AVG SPEED:   500/s   ETA: 0:0:0       
Finished loading files. 2 functions were called.
Analyzing uncalled functions

---------------- analysis summary ----------------
- total time: 0:0:0
- modules loaded: 1
- semantic problems: 1
- failed to parse: 0
- number of definitions: 6
- number of cross references: 6
- number of references: 6
- resolved names: 4
- unresolved names: 3
- name resolve rate:  57%
---------------- memory stats ----------------
- total collections: 0
- total collection time: 0:0:0
- total memory: 360.06M
Exception in thread "main" java.lang.NullPointerException
    at org.yinwang.rubysonar.JSONDump.writeSymJson(JSONDump.java:107)
    at org.yinwang.rubysonar.JSONDump.graph(JSONDump.java:229)
    at org.yinwang.rubysonar.JSONDump.main(JSONDump.java:292)
```

This patch fixes it. There might be more that needs to change; I'm not sure.
