### PR TITLE
fix(Call.java): return attribute type

### DIFF
--- a/src/main/java/org/yinwang/rubysonar/ast/Call.java
+++ b/src/main/java/org/yinwang/rubysonar/ast/Call.java
@@ -100,6 +100,8 @@ public class Call extends Node {
                 } else {
                     return Type.UNKNOWN;
                 }
+            } else {
+                return transformExpr(func, s);
             }
         }
 


### PR DESCRIPTION
Ruby treat mix access attribute and function call. this commit fix one case in which attribute access is considered as function call. 

As in : 
````ruby
class Person
end

person = Person.new
person.name = "hello"
a = person.name
````

`a` should be `str`, previously it's `?` because it's treated as function call instead of attribute access. 