### PR TITLE
Fix 'NestingError: nesting of 100 is too deep' error

### DIFF
--- a/src/main/java/org/yinwang/rubysonar/Analyzer.java
+++ b/src/main/java/org/yinwang/rubysonar/Analyzer.java
@@ -328,11 +328,17 @@ public class Analyzer {
                 }
                 return type;
             }
-        } catch (OutOfMemoryError e) {
+        } catch (OutOfMemoryError | StackOverflowError e) {
             if (astCache != null) {
                 astCache.clear();
             }
             System.gc();
+            if(e instanceof OutOfMemoryError) {
+                _.msg("Skiping for memory size limit: " + file);
+            }
+            if(e instanceof StackOverflowError) {
+                _.msg("Skiping for stack size limit: " + file);
+            }
             return null;
         }
     }

--- a/src/main/java/org/yinwang/rubysonar/AstCache.java
+++ b/src/main/java/org/yinwang/rubysonar/AstCache.java
@@ -13,7 +13,7 @@ import java.util.logging.Logger;
 
 
 /**
- * Provides a factory for python source ASTs.  Maintains configurable on-disk and
+ * Provides a factory for ruby source ASTs.  Maintains configurable on-disk and
  * in-memory caches to avoid re-parsing files during analysis.
  */
 public class AstCache {

--- a/src/main/resources/org/yinwang/rubysonar/ruby/dump_ruby.rb
+++ b/src/main/resources/org/yinwang/rubysonar/ruby/dump_ruby.rb
@@ -882,13 +882,21 @@ class AstSimplifier
 
 end
 
+def hash_nest_max hash
+  if hash.is_a?(Array)
+    hash.map{ |e| (hash_nest_max e).to_i }.max.to_i + 1
+  elsif hash.is_a?(Hash)
+    hash.values.map{ |s| (hash_nest_max s).to_i }.max.to_i + 1
+  else
+    0
+  end
+end
 
 def parse_dump(input, output, endmark)
   begin
     simplifier = AstSimplifier.new(input)
     hash = simplifier.simplify
-
-    json_string = JSON.pretty_generate(hash)
+    json_string = JSON.pretty_generate(hash, max_nesting: (hash_nest_max hash))
     out = File.open(output, 'wb')
     out.write(json_string)
     out.close

--- a/src/main/resources/org/yinwang/rubysonar/ruby/dump_ruby.rb
+++ b/src/main/resources/org/yinwang/rubysonar/ruby/dump_ruby.rb
@@ -882,11 +882,11 @@ class AstSimplifier
 
 end
 
-def hash_nest_max hash
+def hash_max_nest(hash)
   if hash.is_a?(Array)
-    hash.map{ |e| (hash_nest_max e).to_i }.max.to_i + 1
+    hash.map{ |e| hash_max_nest(e).to_i }.max.to_i + 1
   elsif hash.is_a?(Hash)
-    hash.values.map{ |s| (hash_nest_max s).to_i }.max.to_i + 1
+    hash.values.map{ |s| hash_max_nest(s).to_i }.max.to_i + 1
   else
     0
   end
@@ -896,7 +896,7 @@ def parse_dump(input, output, endmark)
   begin
     simplifier = AstSimplifier.new(input)
     hash = simplifier.simplify
-    json_string = JSON.pretty_generate(hash, max_nesting: (hash_nest_max hash))
+    json_string = JSON.pretty_generate(hash, max_nesting: hash_max_nest(hash))
     out = File.open(output, 'wb')
     out.write(json_string)
     out.close


### PR DESCRIPTION
```shell
ruby dump_ruby.rb  dump_ruby.rb res res2
```
will reproduce the bug, according to 
http://ruby-doc.org/stdlib-2.0.0/libdoc/json/rdoc/JSON.html#method-i-pretty_generate

max_nesting default value is 100, add a max_nesting in options will solve it, 
hash_max_nest used to get the max nest of a hash.
