### PR TITLE
missing setSuper() 

### DIFF
--- a/src/main/java/org/yinwang/rubysonar/types/ClassType.java
+++ b/src/main/java/org/yinwang/rubysonar/types/ClassType.java
@@ -41,6 +41,7 @@ public class ClassType extends Type {
         this.superclass = superclass;
         table.setSuper(superclass.table);
         table.updateType("super", superclass);
+        table.setSuper(superclass.table);
     }
 
 

--- a/src/main/java/org/yinwang/rubysonar/types/ClassType.java
+++ b/src/main/java/org/yinwang/rubysonar/types/ClassType.java
@@ -41,7 +41,6 @@ public class ClassType extends Type {
         this.superclass = superclass;
         table.setSuper(superclass.table);
         table.updateType("super", superclass);
-        table.setSuper(superclass.table);
     }
 
 

--- a/src/main/java/org/yinwang/rubysonar/types/InstanceType.java
+++ b/src/main/java/org/yinwang/rubysonar/types/InstanceType.java
@@ -20,6 +20,7 @@ public class InstanceType extends Type {
         table.setStateType(State.StateType.INSTANCE);
         table.setParent(c.table.parent);
         table.setPath(c.table.path);
+        table.setSuper(c.table);
         classType = c;
 
         for (Map.Entry<String, List<Binding>> e : c.table.table.entrySet()) {


### PR DESCRIPTION
```ruby
class Base
  def get
    value
  end

  def value
    raise "implemented in child"
  end
end

class Upper < Base
  def value
    "hello"
  end
end

u = Upper.new
u.get                # `get` method not found by rubysonar because of missing setSuper() 
```