### PR TITLE
`super` and `initialize` related cases

### DIFF
--- a/src/main/java/org/yinwang/rubysonar/ast/Node.java
+++ b/src/main/java/org/yinwang/rubysonar/ast/Node.java
@@ -121,6 +121,18 @@ public abstract class Node implements java.io.Serializable {
     }
 
 
+    @Nullable
+    public Function getOutterFunction() {
+        if (parent == null) {
+            return null;
+        } else if (parent instanceof Function) {
+            return (Function) parent;
+        } else {
+            return parent.getOutterFunction();
+        }
+    }
+
+
     // nodes are equal if they are from the same file and same starting point
     @Override
     public boolean equals(Object obj) {

--- a/src/main/java/org/yinwang/rubysonar/types/InstanceType.java
+++ b/src/main/java/org/yinwang/rubysonar/types/InstanceType.java
@@ -3,6 +3,7 @@ package org.yinwang.rubysonar.types;
 import org.jetbrains.annotations.NotNull;
 import org.yinwang.rubysonar.Analyzer;
 import org.yinwang.rubysonar.Binding;
+import org.yinwang.rubysonar.Constants;
 import org.yinwang.rubysonar.State;
 import org.yinwang.rubysonar.ast.Call;
 import org.yinwang.rubysonar.ast.Name;
@@ -34,12 +35,16 @@ public class InstanceType extends Type {
 
     public InstanceType(@NotNull Type c, Name newName, Call call, List<Type> args) {
         this(c);
-        Type initFunc = table.lookupAttrType("initialize");
-        if (initFunc != null && initFunc instanceof FunType && ((FunType) initFunc).func != null) {
-            List<Binding> bs = table.lookupAttr("initialize");   // can't be null
+        
+        if (newName.id.equals("new")) {
+            List<Binding> bs = table.lookupAttr(Constants.SELFNAME);
             if (newName != null) {
                 Analyzer.self.putRef(newName, bs);
             }
+        }
+        
+        Type initFunc = table.lookupAttrType("initialize");
+        if (initFunc != null && initFunc instanceof FunType && ((FunType) initFunc).func != null) {
             ((FunType) initFunc).setSelfType(this);
             Call.apply((FunType) initFunc, args, null, null, null, null, call);
             ((FunType) initFunc).setSelfType(null);


### PR DESCRIPTION
I found some cases about `super` and `initialize`:

* `super` can refer to any methods, not only `initialize`

* `super` can return a valid type

* `Class.new` always returns an instance of Class, not same as `initialize`

* missing `popStack(call)`
  if call `super` twice, the second `super` will return `Type.UNKNOWN` because the method which `super` refers to is still in stack.

```ruby
class Base
  def initialize
    "init Base ok"
  end

  def self.get
    self.value
  end

  def self.value
    11235
  end
end

class Upper < Base
  def initialize
    s = super              # type of s marked as nil
    p s.class               # print String, type of `Base.initialize`
    "init Upper ok"
  end

  def self.value
    super
  end
end

Upper.new               # `Upper.new` be marked as str, because Upper.initialize is String
p Upper.new.class   # But `Upper.new` should be an instance of Upper

Upper.value               # marked as nil, since `super`returns nil
p Upper.value.class   # `super` in `self.value` refers to `Base.value`, not `Base.initialize` 
```

