### PR TITLE
`self` refers to current class

### DIFF
--- a/src/main/java/org/yinwang/rubysonar/ast/Call.java
+++ b/src/main/java/org/yinwang/rubysonar/ast/Call.java
@@ -82,10 +82,13 @@ public class Call extends Node {
             }
         }
 
-        // Class.new
         Name newName = null;
+        Type clsType = null;
         if (func instanceof Attribute) {
             Attribute afun = (Attribute) func;
+            clsType = afun.target.transform(s);
+
+            // Class.new
             if (afun.attr.id.equals("new")) {
                 func = afun.target;
                 newName = afun.attr;
@@ -104,6 +107,13 @@ public class Call extends Node {
         }
 
         Type fun = transformExpr(func, s);
+
+        // `self` refers to current class
+        if (clsType != null && fun instanceof FunType) {
+            ((FunType) fun).env.update(
+                        Constants.SELFNAME, clsType.table.lookupAttr(Constants.SELFNAME));
+        }
+
         List<Type> pos = resolveList(args, s);
         Map<String, Type> hash = new HashMap<>();
 


### PR DESCRIPTION
```ruby
class Base
  def self.get
    self.value
  end

  def self.value
    :hello
  end
end

class Upper1 < Base
  def self.value
    "hello"
  end
end

Upper1.get         # () -> symbol
```
The type of Upper1.get should be string. I add a binding self to current class (Upper1) to make the type right.



But this change will trigger a new issue:

```ruby
class Upper1 < Base
  def self.value
    "hello"
  end
end

class Upper2 < Base
  def self.value
    11235
  end
end

Upper1.get    # () -> str
Upper2.get    # () -> str
```
Upper1.get and Upper2.share the same base method Base.get, so they are same type because of cache.

I don't know how to solve this issue simply, maybe change structure of `arrows`?
